### PR TITLE
Adds classes for merging cells in the grid

### DIFF
--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -63,6 +63,17 @@
   grid-column: 1 / -1
 }
 
+/* This class is for the cell that will expand to take the place of other merged cells */
+.kie-grid__item--merge-master {
+  --mergeRows: 1; /* set this inline to control how many rows to cover */
+  grid-row: span var(--mergeRows);
+}
+
+/* This class is for the cells that will be removed as part of the merge */
+.kie-grid__item--merge-away {
+  display: none;
+}
+
 /* Filter on column dropdown right-aligned */
 .pf-c-select__menu {
   right: 0;

--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -63,16 +63,18 @@
   grid-column: 1 / -1
 }
 
+/* The .kie-grid--merged class turns the merged cells on */
 /* This class is for the cell that will expand to take the place of other merged cells */
-.kie-grid__item--merge-master {
+.kie-grid--merged .kie-grid__item--merge-master {
   --mergeRows: 1; /* set this inline to control how many rows to cover */
   grid-row: span var(--mergeRows);
 }
 
 /* This class is for the cells that will be removed as part of the merge */
-.kie-grid__item--merge-away {
+.kie-grid--merged .kie-grid__item--merge-away {
   display: none;
-}
+}  
+
 
 /* Filter on column dropdown right-aligned */
 .pf-c-select__menu {


### PR DESCRIPTION
You can set the variable inside an inline style tag, and it will be scoped just to that element. So each "master" merge cell can set the variable locally, and the class styles will handle making the cell span the correct number of rows.

Something to think about - we could nest these styles inside another class along the lines of `.showTheMerge` - then just adding and removing that class would immediately cause the merge to show or not. That way, you could calculate the merge at another time, and turning it on just shows them.